### PR TITLE
refactor/peer-manager: use pointers wisely

### DIFF
--- a/internal/httpapi/clients.go
+++ b/internal/httpapi/clients.go
@@ -64,20 +64,18 @@ func (tun *TunnelAPI) ClientConnect(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Get peer internal representation
-		peer, err := importPeer(oPeer, nil)
+		peer, err := importPeer(oPeer, 0)
 		if err != nil {
 			return nil, err
 		}
 
 		// Validate peer
-		err = peer.Validate("Id", "Ipv4")
-		if err != nil {
+		if err := peer.Validate("ID", "Ipv4"); err != nil {
 			return nil, err
 		}
 
 		// Set peer
-		_, err = tun.manager.ConnectPeer(peer)
-		if err != nil {
+		if err := tun.manager.ConnectPeer(&peer); err != nil {
 			return nil, err
 		}
 
@@ -134,7 +132,6 @@ func (tun *TunnelAPI) ClientConnectUnsafe(w http.ResponseWriter, r *http.Request
 		installationId := uuid.NewMD5(unsafeUUIDSpace, []byte(claims.Subject))
 		sessionId, _ := uuid.NewRandom()
 		peer := types.PeerInfo{
-			Id:      nil,
 			Label:   nil,
 			Type:    &tunType,
 			Ipv4:    nil,
@@ -153,14 +150,12 @@ func (tun *TunnelAPI) ClientConnectUnsafe(w http.ResponseWriter, r *http.Request
 		}
 
 		// Validate peer
-		err = peer.Validate("Id", "Ipv4")
-		if err != nil {
+		if err := peer.Validate("ID", "Ipv4"); err != nil {
 			return nil, err
 		}
 
 		// Set peer
-		_, err = tun.manager.ConnectPeer(&peer)
-		if err != nil {
+		if err := tun.manager.ConnectPeer(&peer); err != nil {
 			return nil, err
 		}
 

--- a/internal/httpapi/ippool.go
+++ b/internal/httpapi/ippool.go
@@ -36,11 +36,11 @@ func (tun *TunnelAPI) AdminIppoolIsUsed(w http.ResponseWriter, r *http.Request) 
 		}
 
 		ipa := xnet.ParseIP(req.IpAddress)
-		if ipa == nil {
+		if ipa.IP == nil {
 			return nil, xerror.EInvalidField("failed to parse given IP address", "ip_address", nil)
 		}
 
-		if !tun.ippool.IsAvailable(*ipa) {
+		if !tun.ippool.IsAvailable(ipa) {
 			return nil, xerror.EInvalidField("given IP address is not available", "ip_address", nil)
 		}
 

--- a/internal/storage/common.go
+++ b/internal/storage/common.go
@@ -63,6 +63,13 @@ func getFields(i interface{}, omitNull bool) (columns []string) {
 	for i := 0; i < v.NumField(); i++ {
 		columnName := v.Type().Field(i).Tag.Get("db")
 
+		fName := v.Type().Field(i).Name
+		if fName == "ID" {
+			if v.Field(i).IsZero() {
+				continue
+			}
+		}
+
 		field := v.Field(i)
 		if columnName != "" {
 			if omitNull && field.Kind() == reflect.Ptr && field.IsNil() {

--- a/internal/storage/peers.go
+++ b/internal/storage/peers.go
@@ -1,25 +1,29 @@
 package storage
 
 import (
-	"fmt"
-
 	"github.com/Codename-Uranium/tunnel/internal/types"
 	"github.com/Codename-Uranium/tunnel/pkg/xerror"
 	"github.com/Codename-Uranium/tunnel/pkg/xtime"
 	"go.uber.org/zap"
 )
 
-func (storage *Storage) SearchPeers(peer *types.PeerInfo) ([]types.PeerInfo, error) {
-	query, err := getSelectRequest("peers", peer)
-	if err != nil {
-		return nil, xerror.EStorageError("can't get peer select query", err, zap.Any("peer", peer))
+func (storage *Storage) SearchPeers(filter *types.PeerInfo) ([]types.PeerInfo, error) {
+	if filter == nil {
+		// tolerate nil
+		filter = &types.PeerInfo{}
 	}
 
-	zap.L().Debug("search peers", zap.Any("peer", peer), zap.String("query", query))
-
-	rows, err := storage.db.NamedQuery(query, peer)
+	zapFilter := zap.Any("filter", filter)
+	query, err := getSelectRequest("peers", filter)
 	if err != nil {
-		return nil, xerror.EStorageError("can't lookup peers", err, zap.Any("peer", peer))
+		return nil, xerror.EStorageError("can't get peer select query", err, zapFilter)
+	}
+
+	zap.L().Debug("search peers", zapFilter, zap.String("query", query))
+
+	rows, err := storage.db.NamedQuery(query, filter)
+	if err != nil {
+		return nil, xerror.EStorageError("can't lookup peers", err, zapFilter)
 	}
 
 	var peers []types.PeerInfo
@@ -27,13 +31,13 @@ func (storage *Storage) SearchPeers(peer *types.PeerInfo) ([]types.PeerInfo, err
 		var p types.PeerInfo
 		err = rows.StructScan(&p)
 		if err != nil {
-			zap.L().Error("can't scan peer", zap.Error(err), zap.Any("peer", peer))
+			zap.L().Error("can't scan peer", zap.Error(err), zapFilter)
 			continue
 		}
 
 		// We must ensure database integrity
 		if err := p.Validate(); err != nil {
-			zap.L().Error("skipping invalid peer", zap.Error(err), zap.Any("peer", peer))
+			zap.L().Error("skipping invalid peer", zap.Error(err), zapFilter)
 			continue
 		}
 
@@ -43,10 +47,10 @@ func (storage *Storage) SearchPeers(peer *types.PeerInfo) ([]types.PeerInfo, err
 	return peers, nil
 }
 
-func (storage *Storage) CreatePeer(peer *types.PeerInfo) (*int64, error) {
-	err := peer.Validate("Id")
+func (storage *Storage) CreatePeer(peer types.PeerInfo) (int64, error) {
+	err := peer.Validate("ID")
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	// Fill in create and update timestamp
@@ -58,29 +62,28 @@ func (storage *Storage) CreatePeer(peer *types.PeerInfo) (*int64, error) {
 
 	query, err := getInsertRequest("peers", peer)
 	if err != nil {
-		return nil, xerror.EStorageError("can't insert peer", err, zap.Any("peer", peer))
+		return -1, xerror.EStorageError("can't insert peer", err, zap.Any("peer", peer))
 	}
 
 	zap.L().Debug("Create peer", zap.Any("peer", peer), zap.String("query", query))
 
 	res, err := storage.db.NamedExec(query, peer)
 	if err != nil {
-		return nil, xerror.EStorageError("can't insert peer to sqlite", err, zap.Any("peer", peer), zap.String("query", query))
+		return -1, xerror.EStorageError("can't insert peer to sqlite", err, zap.Any("peer", peer), zap.String("query", query))
 	}
 
 	id, err := res.LastInsertId()
 	if err != nil {
-		return nil, xerror.EStorageError("can't get peer id after insert", err, zap.Any("peer", peer), zap.String("query", query))
+		return -1, xerror.EStorageError("can't get peer id after insert", err, zap.Any("peer", peer), zap.String("query", query))
 	}
 
-	peer.Id = &id
-	return peer.Id, nil
+	return id, nil
 }
 
-func (storage *Storage) UpdatePeer(peer *types.PeerInfo) (*int64, error) {
+func (storage *Storage) UpdatePeer(peer types.PeerInfo) (int64, error) {
 	err := peer.Validate()
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
 	// Fill in update timestamp
@@ -91,54 +94,49 @@ func (storage *Storage) UpdatePeer(peer *types.PeerInfo) (*int64, error) {
 	zap.L().Debug("Update peer", zap.Any("peer", peer), zap.String("query", query))
 
 	if err != nil {
-		return nil, xerror.EStorageError("can't insert peer", err, zap.Any("peer", peer))
+		return -1, xerror.EStorageError("can't insert peer", err, zap.Any("peer", peer))
 	}
 
-	zap.L().Debug("Update peer", zap.Any("peer", peer), zap.String("query", query))
-
-	_, err = storage.db.NamedExec(query, peer)
-	if err != nil {
-		return nil, xerror.EStorageError("can't update peer in sqlite", err, zap.Any("peer", peer), zap.String("query", query))
+	if _, err := storage.db.NamedExec(query, peer); err != nil {
+		return -1, xerror.EStorageError("can't update peer in sqlite", err, zap.Any("peer", peer), zap.String("query", query))
 	}
 
-	return peer.Id, nil
+	return peer.ID, nil
 }
 
-func (storage *Storage) GetPeer(id int64) (*types.PeerInfo, error) {
-	peer := types.PeerInfo{
-		Id: &id,
-	}
-
-	peers, err := storage.SearchPeers(&peer)
+func (storage *Storage) GetPeer(id int64) (types.PeerInfo, error) {
+	filter := &types.PeerInfo{ID: id}
+	peers, err := storage.SearchPeers(filter)
 	if err != nil {
-		return nil, err
+		return types.PeerInfo{}, err
 	}
 
 	if len(peers) == 0 {
 		zap.L().Warn("Peer not found", zap.Any("id", id))
-		return nil, nil
+		return types.PeerInfo{}, nil
 	}
 
 	if len(peers) > 1 {
-		return nil, xerror.EStorageError("too many entries in request by ID", nil, zap.Int64("id", id))
+		// TODO(nikonov): must hever happen since we have a PK/UK constraint on the ID field,
+		//  maybe worth panic()-ing right here.
+		return types.PeerInfo{}, xerror.EStorageError("too many entries in request by ID", nil, zap.Int64("id", id))
 	}
 
-	err = peers[0].Validate()
-	if err != nil {
-		return nil, err
+	peer := peers[0]
+	if err := peer.Validate(); err != nil {
+		return types.PeerInfo{}, err
 	}
 
-	zap.L().Debug("Get peer", zap.Any("id", id), zap.Any("peer", peer))
-	return &peers[0], nil
+	zap.L().Debug("get peer result", zap.Int64("id", id), zap.Any("peer", peer))
+	return peer, nil
 }
 
 func (storage *Storage) DeletePeer(id int64) error {
-	query := fmt.Sprintf("DELETE FROM peers WHERE id=%v", id)
-	zap.L().Debug("Delete peer", zap.Any("id", id), zap.String("query", query))
+	zap.L().Debug("Delete peer", zap.Any("id", id))
 
-	_, err := storage.db.Exec(query)
-	if err != nil {
-		return xerror.EStorageError("can't execute delete sql request", err, zap.Int64("id", id), zap.String("query", query))
+	q := `delete from peers where id = ?`
+	if _, err := storage.db.Exec(q, id); err != nil {
+		return xerror.EStorageError("failed to delete peer", err, zap.Int64("id", id))
 	}
 
 	return nil

--- a/internal/types/peer_info.go
+++ b/internal/types/peer_info.go
@@ -28,7 +28,10 @@ type PeerIdentifiers struct {
 }
 
 type PeerInfo struct {
-	Id      *int64      `db:"id"`
+	WireguardInfo
+	PeerIdentifiers
+
+	ID      int64       `db:"id"`
 	Label   *string     `db:"label"`
 	Type    *int        `db:"type"`
 	Ipv4    *xnet.IP    `db:"ipv4" json:"-"`
@@ -36,8 +39,6 @@ type PeerInfo struct {
 	Updated *xtime.Time `db:"updated"`
 	Expires *xtime.Time `db:"expires"`
 	Claims  *string     `db:"claims"`
-	WireguardInfo
-	PeerIdentifiers
 }
 
 func (peer *PeerInfo) IntoProto() *proto.PeerInfo {
@@ -117,7 +118,7 @@ func (peer *PeerInfo) Validate(omit ...string) error {
 	}
 
 	// Check auto-generated fields with ability to omit in validation
-	if !in("Id", omit) && peer.Id == nil {
+	if !in("ID", omit) && peer.ID == 0 {
 		return xerror.EInvalidArgument("empty peer id", nil)
 	}
 

--- a/internal/wireguard/internal.go
+++ b/internal/wireguard/internal.go
@@ -25,7 +25,7 @@ type Config struct {
 
 // getPeerConfig generates wireguard configuration for a peer.
 // Note: it's caller responsibility to provide fully valid peer
-func (wg *Wireguard) getPeerConfig(info *types.PeerInfo, remove bool) (*wgtypes.Config, error) {
+func (wg *Wireguard) getPeerConfig(info types.PeerInfo, remove bool) (*wgtypes.Config, error) {
 	if *info.Type != types.TunnelWireguard {
 		return nil, xerror.ETunnelError("can't configure non-wireguard peer in wireguard module", nil, zap.Int("type", *info.Type))
 	}

--- a/internal/wireguard/wireguard_darwin.go
+++ b/internal/wireguard/wireguard_darwin.go
@@ -22,12 +22,12 @@ func (w *Wireguard) Shutdown() error {
 
 func (w *Wireguard) Running() bool { return w.running }
 
-func (*Wireguard) SetPeer(info *types.PeerInfo) error {
+func (*Wireguard) SetPeer(info types.PeerInfo) error {
 	zap.L().Debug("wg: set peer")
 	return nil
 }
 
-func (*Wireguard) UnsetPeer(info *types.PeerInfo) error {
+func (*Wireguard) UnsetPeer(info types.PeerInfo) error {
 	zap.L().Debug("wg: unset peer")
 	return nil
 }

--- a/internal/wireguard/wireguard_linux.go
+++ b/internal/wireguard/wireguard_linux.go
@@ -102,7 +102,7 @@ func (wg *Wireguard) Running() bool {
 
 // SetPeer sets peer on wireguard interface
 // Note: it's caller responsibility to provide fully valid peer
-func (wg *Wireguard) SetPeer(info *types.PeerInfo) error {
+func (wg *Wireguard) SetPeer(info types.PeerInfo) error {
 	zap.L().Debug("Set peer", zap.Any("peer", info))
 
 	config, err := wg.getPeerConfig(info, false)
@@ -120,7 +120,7 @@ func (wg *Wireguard) SetPeer(info *types.PeerInfo) error {
 
 // UnsetPeer removes peer from wireguard interface
 // Note: it's caller responsibility to provide fully valid peer
-func (wg *Wireguard) UnsetPeer(info *types.PeerInfo) error {
+func (wg *Wireguard) UnsetPeer(info types.PeerInfo) error {
 	zap.L().Debug("Unset peer", zap.Any("peer", info))
 
 	config, err := wg.getPeerConfig(info, true)

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -173,7 +173,7 @@ func isSubnet(value interface{}, _ interface{}) bool {
 	}
 
 	// must be the network address, not the host one
-	if !ipn.IP().Equal(ipa) {
+	if !ipn.IP().Equal(*ipa) {
 		return false
 	}
 

--- a/pkg/xnet/ip.go
+++ b/pkg/xnet/ip.go
@@ -17,7 +17,7 @@ func (ip IP) Isv4() bool {
 	return ip.IP.To4() != nil
 }
 
-func (ip IP) Equal(other *IP) bool {
+func (ip IP) Equal(other IP) bool {
 	return ip.IP.Equal(other.IP)
 }
 
@@ -25,13 +25,13 @@ func (ip IP) String() string {
 	return ip.IP.String()
 }
 
-func ParseIP(s string) *IP {
+func ParseIP(s string) IP {
 	ip := net.ParseIP(s)
 	if ip == nil {
-		return nil
+		return IP{}
 	}
 
-	return &IP{ip}
+	return IP{ip}
 }
 
 type IPNet struct {


### PR DESCRIPTION
Avoid pointers to standard types (int, string, time) if possible. 