### PR TITLE
WIP/ci: build personal image first

### DIFF
--- a/.github/workflows/on-manual-enterprise.yaml
+++ b/.github/workflows/on-manual-enterprise.yaml
@@ -1,0 +1,30 @@
+name: "Manually/personal: build image"
+
+on: workflow_dispatch
+
+jobs:
+  build_image:
+    name: "personal :: build image"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cleanup the ref name
+        # turns "refs/heads/fix/this-and-that" into
+        # the docker-tag-friendly "fix-this-and-that".
+        run: echo "GITHUB_REF_SHORT=$(echo $GITHUB_REF | sed -e 's/refs\/heads\///' -e 's/\//-/')" >> $GITHUB_ENV
+
+      - name: login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build_args: TARGET=build/linux/personal
+          file: docker/tunnel/Dockerfile
+          push: true
+          tags: codenameuranium/tunnel:personal-${{ env.GITHUB_REF_SHORT }}

--- a/.github/workflows/on-manual-personal.yaml
+++ b/.github/workflows/on-manual-personal.yaml
@@ -1,10 +1,10 @@
-name: "Manually: build testing images"
+name: "Manually/enterprise: build image"
 
 on: workflow_dispatch
 
 jobs:
   build_image:
-    name: "build image"
+    name: "enterprise :: build image"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +24,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build_args: TARGET=build/linux
           file: docker/tunnel/Dockerfile
           push: true
           tags: codenameuranium/tunnel:${{ env.GITHUB_REF_SHORT }}

--- a/.github/workflows/on-merge-into-main.yaml
+++ b/.github/workflows/on-merge-into-main.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build_args: TARGET=build/linux/personal
           file: docker/tunnel/Dockerfile
           push: true
-          tags: codenameuranium/tunnel:main
+          tags: codenameuranium/tunnel:personal-latest

--- a/.github/workflows/on-tag-release.yaml
+++ b/.github/workflows/on-tag-release.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build_args: TARGET=build/linux/personal
           file: docker/tunnel/Dockerfile
           push: true
-          tags: codenameuranium/tunnel:latest,codenameuranium/tunnel:${{ steps.get_version.outputs.TAG_VERSION }}
+          tags: codenameuranium/tunnel:personal-${{ steps.get_version.outputs.TAG_VERSION }}


### PR DESCRIPTION
This PR also renames docker tags to something more docker-established:
* `tunnel:latest` for the latest non-stable version built from the `main` branch;
* `tunnel:vX.Y.Z` for the particular release version; 