### PR TITLE
refactor: make optional configuration parts nullabe and non-marshalable

### DIFF
--- a/internal/httpapi/auth.go
+++ b/internal/httpapi/auth.go
@@ -46,7 +46,7 @@ func (tun *TunnelAPI) AdminDoAuth(w http.ResponseWriter, r *http.Request) {
 
 		// Create claims
 		issued := time.Now().Unix()
-		expires := issued + int64(tun.runtime.Settings.AdminAPI.TokenLifetime)
+		expires := issued + int64(tun.runtime.Settings.GetAdminAPConfig().TokenLifetime)
 		claims := jwt.StandardClaims{
 			IssuedAt:  issued,
 			ExpiresAt: expires,

--- a/internal/httpapi/clients.go
+++ b/internal/httpapi/clients.go
@@ -90,7 +90,7 @@ func (tun *TunnelAPI) ClientConnect(w http.ResponseWriter, r *http.Request) {
 				ServerIpv4:      wgSettings.ServerIPv4,
 				ServerPort:      wgSettings.ServerPort,
 				ServerPublicKey: tun.runtime.DynamicSettings.GetWireguardPrivateKey().Public().Unwrap().String(),
-				PingInterval:    tun.runtime.Settings.PublicAPI.PingInterval,
+				PingInterval:    tun.runtime.Settings.GetPublicAPIConfig().PingInterval,
 			},
 		}
 
@@ -292,7 +292,7 @@ func (tun *TunnelAPI) extractPeerActionInfo(r *http.Request) (*types.PeerIdentif
 }
 
 func (tun *TunnelAPI) getExpiration() *time.Time {
-	settings := tun.runtime.Settings.PublicAPI
+	settings := tun.runtime.Settings.GetPublicAPIConfig()
 	expiresSeconds := settings.PingInterval + settings.PeerTTL
 	expires := time.Now().Add(time.Second * time.Duration(expiresSeconds))
 	return &expires

--- a/internal/httpapi/instance.go
+++ b/internal/httpapi/instance.go
@@ -57,7 +57,7 @@ func NewTunnelHandlers(
 
 func (tun *TunnelAPI) RegisterHandlers(r chi.Router) {
 	// handle frontend redirects
-	root := tun.runtime.Settings.AdminAPI.StaticRoot
+	root := tun.runtime.Settings.GetAdminAPConfig().StaticRoot
 	r.HandleFunc("/", wrap404ToIndex(http.FileServer(http.Dir(root))))
 
 	// admin API

--- a/internal/httpapi/internal.go
+++ b/internal/httpapi/internal.go
@@ -57,7 +57,7 @@ func wrap404ToIndex(h http.Handler) http.HandlerFunc {
 
 // adminCheckBasicAuth only checks if basic authentication is successful
 func (tun *TunnelAPI) adminCheckBasicAuth(username string, password string) error {
-	if username != tun.runtime.Settings.AdminAPI.UserName {
+	if username != tun.runtime.Settings.GetAdminAPConfig().UserName {
 		return xerror.EAuthenticationFailed("invalid credentials", nil)
 	}
 

--- a/internal/httpapi/settings.go
+++ b/internal/httpapi/settings.go
@@ -102,12 +102,12 @@ func settingsToOpenAPI(s settings.StaticConfig, d settings.DynamicConfig) adminA
 	public := d.GetWireguardPrivateKey().Public().Unwrap().String()
 	subnet := string(s.Wireguard.Subnet)
 	return adminAPI.Settings{
-		AdminUserName:       &s.AdminAPI.UserName,
-		ConnectionTimeout:   &s.PublicAPI.PeerTTL,
+		AdminUserName:       &s.GetAdminAPConfig().UserName,
+		ConnectionTimeout:   &s.GetPublicAPIConfig().PeerTTL,
 		Dns:                 &s.Wireguard.DNS,
 		HttpListenAddr:      &s.HTTPListenAddr,
 		LogLevel:            (*adminAPI.SettingsLogLevel)(&s.LogLevel),
-		PingInterval:        &s.PublicAPI.PingInterval,
+		PingInterval:        &s.GetPublicAPIConfig().PingInterval,
 		WireguardKeepalive:  &s.Wireguard.Keepalive,
 		WireguardListenPort: &s.Wireguard.ServerPort,
 		WireguardPublicKey:  &public,
@@ -122,13 +122,6 @@ func mergeStaticSettings(current settings.StaticConfig, s adminAPI.Settings) set
 	}
 	if s.HttpListenAddr != nil {
 		current.HTTPListenAddr = *s.HttpListenAddr
-	}
-
-	if s.ConnectionTimeout != nil {
-		current.PublicAPI.PeerTTL = *s.ConnectionTimeout
-	}
-	if s.PingInterval != nil {
-		current.PublicAPI.PingInterval = *s.PingInterval
 	}
 
 	if s.Dns != nil {


### PR DESCRIPTION
This PR significantly decreases the number of the required parameters in the config file. 
Less options -> less explanation in the docs -> less points of misconfiguration -> more clarity!
