### PR TITLE
fix: start http listener separately allowing better error handling

### DIFF
--- a/cmd/tunnel/main.go
+++ b/cmd/tunnel/main.go
@@ -111,7 +111,9 @@ func initServices(runtime *runtime.TunnelRuntime) error {
 	}
 
 	// Startup HTTP API
-	go hs.Run(runtime.Settings.HTTPListenAddr)
+	if err := hs.Run(runtime.Settings.HTTPListenAddr); err != nil {
+		return err
+	}
 	runtime.Services.RegisterService("httpServer", hs)
 
 	if runtime.Features.WithGRPC() {


### PR DESCRIPTION
Separate listener initialization allows us to catch the common "address already in use" error and so gracefully stop the process. 